### PR TITLE
Move base64 decode table out of function to reduce function complexity

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -17,6 +17,7 @@ coverity
 ctest
 misra
 mqtt
+nondet
 sizet
 stringz
 tinycbor

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -19,8 +19,8 @@
     </tr>
     <tr>
         <td>MQTTFileDownloader_base64.c</td>
-        <td><center>0.7K</center></td>
-        <td><center>0.7K</center></td>
+        <td><center>0.6K</center></td>
+        <td><center>0.6K</center></td>
     </tr>
     <tr>
         <td>core_json.c</td>
@@ -44,7 +44,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>10.2K</center></b></td>
-        <td><b><center>7.5K</center></b></td>
+        <td><b><center>10.1K</center></b></td>
+        <td><b><center>7.4K</center></b></td>
     </tr>
 </table>

--- a/source/MQTTFileDownloader_base64.c
+++ b/source/MQTTFileDownloader_base64.c
@@ -103,6 +103,56 @@
  */
 #define BASE64_INDEX_VALUE_UPPER_BOUND           63U
 
+    /**
+     * @brief This table takes is indexed by an Ascii character and returns the
+     * respective Base64 index. The Ascii character used to index into this table is
+     * assumed to represent a symbol in a string of Base64 encoded data. There are
+     * three kinds of possible ascii characters: 1) Base64 Symbols. These are the
+     * digits of a Base 64 number system. 2) Formatting characters. These are
+     * newline, whitespace, and padding. 3) Symbols that are impossible to have
+     * inside of correctly Base64 encoded data.
+     *
+     *        This table assumes that the padding symbol is the Ascii character '='
+     *
+     *        Valid Base64 symbols will have an index ranging from 0-63. The Base64
+     * digits being used are
+     * "ABCDEFGHIJKLMNOPQRSTUVWXYabcdefghijklmnopqrstuvwxyz0123456789+/" where 'A'
+     * is the 0th index of the Base64 symbols and '/' is the 63rd index.
+     *
+     *        Outside of the numbers 0-63, there are magic numbers in this table:
+     *        - The 11th entry in this table has the number 64. This is to identify
+     * the ascii character
+     *          '\n' as a newline character.
+     *        - The 14th entry in this table has the number 64. This is to identify
+     * the ascii character
+     *          '\\r' as a newline character.
+     *        - The 33rd entry in this table has the number 65. This is to identify
+     * the ascii character ' ' as a whitespace character.
+     *        - The 62nd entry in this table has the number 66. This is to identify
+     * the ascii character
+     *          '=' as the padding character.
+     *        - All positions in the ascii table that are invalid symbols are
+     * identified with the number 67 (other than '\n','\\r',' ','=').
+     */
+    static const uint8_t base64SymbolToIndexMap[] =
+    {
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 64, 67, 67, 64, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 65, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 62, 67, 67, 67, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+        61, 67, 67, 67, 66, 67, 67, 67, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+        11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 67, 67, 67, 67,
+        67, 67, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+        43, 44, 45, 46, 47, 48, 49, 50, 51, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+        67, 67, 67, 67, 67, 67, 67, 67, 67
+    };
+
+
 /**
  * @brief         Validates the input Base64 index based on the context of what
  *                has been decoded so far and the value of the index. Updates
@@ -361,54 +411,6 @@ Base64Status_t base64_Decode( uint8_t * dest,
                               const uint8_t * encodedData,
                               const size_t encodedLen )
 {
-    /**
-     * @brief This table takes is indexed by an Ascii character and returns the
-     * respective Base64 index. The Ascii character used to index into this table is
-     * assumed to represent a symbol in a string of Base64 encoded data. There are
-     * three kinds of possible ascii characters: 1) Base64 Symbols. These are the
-     * digits of a Base 64 number system. 2) Formatting characters. These are
-     * newline, whitespace, and padding. 3) Symbols that are impossible to have
-     * inside of correctly Base64 encoded data.
-     *
-     *        This table assumes that the padding symbol is the Ascii character '='
-     *
-     *        Valid Base64 symbols will have an index ranging from 0-63. The Base64
-     * digits being used are
-     * "ABCDEFGHIJKLMNOPQRSTUVWXYabcdefghijklmnopqrstuvwxyz0123456789+/" where 'A'
-     * is the 0th index of the Base64 symbols and '/' is the 63rd index.
-     *
-     *        Outside of the numbers 0-63, there are magic numbers in this table:
-     *        - The 11th entry in this table has the number 64. This is to identify
-     * the ascii character
-     *          '\n' as a newline character.
-     *        - The 14th entry in this table has the number 64. This is to identify
-     * the ascii character
-     *          '\\r' as a newline character.
-     *        - The 33rd entry in this table has the number 65. This is to identify
-     * the ascii character ' ' as a whitespace character.
-     *        - The 62nd entry in this table has the number 66. This is to identify
-     * the ascii character
-     *          '=' as the padding character.
-     *        - All positions in the ascii table that are invalid symbols are
-     * identified with the number 67 (other than '\n','\\r',' ','=').
-     */
-    const uint8_t base64SymbolToIndexMap[] =
-    {
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 64, 67, 67, 64, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 65, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 62, 67, 67, 67, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
-        61, 67, 67, 67, 66, 67, 67, 67, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-        11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 67, 67, 67, 67,
-        67, 67, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
-        43, 44, 45, 46, 47, 48, 49, 50, 51, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67
-    };
     uint32_t base64IndexBuffer = 0;
     uint32_t numDataInBuffer = 0;
     const uint8_t * pCurrBase64Symbol = encodedData;

--- a/source/MQTTFileDownloader_base64.c
+++ b/source/MQTTFileDownloader_base64.c
@@ -103,54 +103,54 @@
  */
 #define BASE64_INDEX_VALUE_UPPER_BOUND           63U
 
-    /**
-     * @brief This table takes is indexed by an Ascii character and returns the
-     * respective Base64 index. The Ascii character used to index into this table is
-     * assumed to represent a symbol in a string of Base64 encoded data. There are
-     * three kinds of possible ascii characters: 1) Base64 Symbols. These are the
-     * digits of a Base 64 number system. 2) Formatting characters. These are
-     * newline, whitespace, and padding. 3) Symbols that are impossible to have
-     * inside of correctly Base64 encoded data.
-     *
-     *        This table assumes that the padding symbol is the Ascii character '='
-     *
-     *        Valid Base64 symbols will have an index ranging from 0-63. The Base64
-     * digits being used are
-     * "ABCDEFGHIJKLMNOPQRSTUVWXYabcdefghijklmnopqrstuvwxyz0123456789+/" where 'A'
-     * is the 0th index of the Base64 symbols and '/' is the 63rd index.
-     *
-     *        Outside of the numbers 0-63, there are magic numbers in this table:
-     *        - The 11th entry in this table has the number 64. This is to identify
-     * the ascii character
-     *          '\n' as a newline character.
-     *        - The 14th entry in this table has the number 64. This is to identify
-     * the ascii character
-     *          '\\r' as a newline character.
-     *        - The 33rd entry in this table has the number 65. This is to identify
-     * the ascii character ' ' as a whitespace character.
-     *        - The 62nd entry in this table has the number 66. This is to identify
-     * the ascii character
-     *          '=' as the padding character.
-     *        - All positions in the ascii table that are invalid symbols are
-     * identified with the number 67 (other than '\n','\\r',' ','=').
-     */
-    static const uint8_t base64SymbolToIndexMap[] =
-    {
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 64, 67, 67, 64, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 65, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 62, 67, 67, 67, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
-        61, 67, 67, 67, 66, 67, 67, 67, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-        11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 67, 67, 67, 67,
-        67, 67, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
-        43, 44, 45, 46, 47, 48, 49, 50, 51, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
-        67, 67, 67, 67, 67, 67, 67, 67, 67
-    };
+/**
+ * @brief This table takes is indexed by an Ascii character and returns the
+ * respective Base64 index. The Ascii character used to index into this table is
+ * assumed to represent a symbol in a string of Base64 encoded data. There are
+ * three kinds of possible ascii characters: 1) Base64 Symbols. These are the
+ * digits of a Base 64 number system. 2) Formatting characters. These are
+ * newline, whitespace, and padding. 3) Symbols that are impossible to have
+ * inside of correctly Base64 encoded data.
+ *
+ *        This table assumes that the padding symbol is the Ascii character '='
+ *
+ *        Valid Base64 symbols will have an index ranging from 0-63. The Base64
+ * digits being used are
+ * "ABCDEFGHIJKLMNOPQRSTUVWXYabcdefghijklmnopqrstuvwxyz0123456789+/" where 'A'
+ * is the 0th index of the Base64 symbols and '/' is the 63rd index.
+ *
+ *        Outside of the numbers 0-63, there are magic numbers in this table:
+ *        - The 11th entry in this table has the number 64. This is to identify
+ * the ascii character
+ *          '\n' as a newline character.
+ *        - The 14th entry in this table has the number 64. This is to identify
+ * the ascii character
+ *          '\\r' as a newline character.
+ *        - The 33rd entry in this table has the number 65. This is to identify
+ * the ascii character ' ' as a whitespace character.
+ *        - The 62nd entry in this table has the number 66. This is to identify
+ * the ascii character
+ *          '=' as the padding character.
+ *        - All positions in the ascii table that are invalid symbols are
+ * identified with the number 67 (other than '\n','\\r',' ','=').
+ */
+static const uint8_t base64SymbolToIndexMap[] =
+{
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 64, 67, 67, 64, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 65, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 62, 67, 67, 67, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+    61, 67, 67, 67, 66, 67, 67, 67, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 67, 67, 67, 67,
+    67, 67, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, 46, 47, 48, 49, 50, 51, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67,
+    67, 67, 67, 67, 67, 67, 67, 67, 67
+};
 
 
 /**

--- a/source/include/MQTTFileDownloader.h
+++ b/source/include/MQTTFileDownloader.h
@@ -60,7 +60,7 @@
  * @ingroup mqtt_file_downloader_const_types
  * @brief Configure the Maximum size of the data payload.
  */
-#define mqttFileDownloader_CONFIG_BLOCK_SIZE    512U
+#define mqttFileDownloader_CONFIG_BLOCK_SIZE    256U
 
 /**
  * @brief Macro to calculate string length.

--- a/source/include/MQTTFileDownloader.h
+++ b/source/include/MQTTFileDownloader.h
@@ -60,7 +60,7 @@
  * @ingroup mqtt_file_downloader_const_types
  * @brief Configure the Maximum size of the data payload.
  */
-#define mqttFileDownloader_CONFIG_BLOCK_SIZE    256U
+#define mqttFileDownloader_CONFIG_BLOCK_SIZE    512U
 
 /**
  * @brief Macro to calculate string length.


### PR DESCRIPTION
This PR moves a base64 decoding table out of local function scope and makes it global static const variable.

This reduces the function complexity from 32 -> 6 due to reduced line count.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
