### PR TITLE
Update API to return the fileID, blockID and blockSize

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,8 +9,8 @@
     </tr>
     <tr>
         <td>MQTTFileDownloader.c</td>
-        <td><center>0.9K</center></td>
-        <td><center>0.8K</center></td>
+        <td><center>1.1K</center></td>
+        <td><center>1.0K</center></td>
     </tr>
     <tr>
         <td>MQTTFileDownloader_cbor.c</td>
@@ -44,7 +44,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>10.1K</center></b></td>
-        <td><b><center>7.4K</center></b></td>
+        <td><b><center>10.3K</center></b></td>
+        <td><b><center>7.6K</center></b></td>
     </tr>
 </table>

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -95,11 +95,11 @@ static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
  *
  * @param[in] message Incoming MQTT message received.
  * @param[in] messageLength Length of the MQTT message received.
- * @param[out] decodedData Buffer to place the decoded data in.
- * @param[out] decodedDataLength Length of decoded data.
  * @param[out] fileId ID of the file to which the data block belongs.
  * @param[out] blockId ID of the received block.
  * @param[out] blockSize Size of the receive block in bytes.
+ * @param[out] decodedData Buffer to place the decoded data in.
+ * @param[out] decodedDataLength Length of decoded data.
  *
  * @return uint8_t returns appropriate MQTT File Downloader Status.
  */
@@ -112,20 +112,21 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
                                                      size_t * decodedDataLength );
 
 /**
- * @brief Handles and decodes the received message in JSON format.
+ * @brief Parses C-string interpreting its contents as a POSITIVE
+ *        int32_t number.
  *
  * @param[in] str String which has the ASCII representation of the
  *            number.
  * @param[in] len Length of the string.
  * @param[out] num Pointer to an int32_t variable which will be filled
  *            with the parsed value. If the return value of the function
- *            call is -1, then the value present in num is invalid.
+ *            call is false, then the value present in num is invalid.
  *
  * @return bool if the string is malformed or the decoded number
  * cannot fit in an int32_t value then this function returns false. On
  * successful parsing, it returns true.
  */
-static bool getNumberFromString( char * str,
+static bool getNumberFromString( const char * str,
                                  size_t len,
                                  int32_t * num );
 
@@ -375,7 +376,7 @@ static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
     return handleStatus;
 }
 
-static bool getNumberFromString( char * str,
+static bool getNumberFromString( const char * str,
                                  size_t len,
                                  int32_t * num )
 {
@@ -387,11 +388,11 @@ static bool getNumberFromString( char * str,
     /* Biggest number which can fit in an int32_t is 2147483647 which has 10 digits. */
     assert( len <= 10 );
 
-    for( int i = 0; i < len; i++ )
+    for( size_t uxIndex = 0U; uxIndex < len; uxIndex++ )
     {
-        if( IS_CHAR_DIGIT( str[ i ] ) != 0 )
+        if( IS_CHAR_DIGIT( str[ uxIndex ] ) == true )
         {
-            digit = CHAR_TO_DIGIT( str[ i ] );
+            digit = CHAR_TO_DIGIT( str[ uxIndex ] );
 
             if( ( maxValue / 10 ) < out )
             {

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -121,13 +121,13 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
  *            with the parsed value. If the return value of the function
  *            call is -1, then the value present in num is invalid.
  *
- * @return int32_t if the string is malformed or the decoded number
- * cannot fit in an int32_t value then this function returns -1. On
- * successful parsing, it returns 0.
+ * @return bool if the string is malformed or the decoded number
+ * cannot fit in an int32_t value then this function returns false. On
+ * successful parsing, it returns true.
  */
-static int32_t getNumberFromString( char * str,
-                                    size_t len,
-                                    int32_t * num );
+static bool getNumberFromString( char * str,
+                                 size_t len,
+                                 int32_t * num );
 
 static size_t stringBuilder( char * buffer,
                              size_t bufferSizeBytes,
@@ -375,13 +375,13 @@ static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
     return handleStatus;
 }
 
-static int32_t getNumberFromString( char * str,
-                                    size_t len,
-                                    int32_t * num )
+static bool getNumberFromString( char * str,
+                                 size_t len,
+                                 int32_t * num )
 {
     int32_t out = 0;
     int32_t digit;
-    int retVal = 0;
+    bool retVal = true;
     const int32_t maxValue = 2147483647;
 
     /* Biggest number which can fit in an int32_t is 2147483647 which has 10 digits. */
@@ -396,13 +396,13 @@ static int32_t getNumberFromString( char * str,
             if( ( maxValue / 10 ) < out )
             {
                 /* The out value will overflow on multiplication with 10. */
-                retVal = -1;
+                retVal = false;
             }
             else if( ( maxValue - digit ) < ( out * 10 ) )
             {
                 /* The value ( out * 10 ) will overflow when the digit is
                  * added to it. */
-                retVal = -1;
+                retVal = false;
             }
             else
             {
@@ -411,16 +411,16 @@ static int32_t getNumberFromString( char * str,
         }
         else
         {
-            retVal = -1;
+            retVal = false;
         }
 
-        if( retVal < 0 )
+        if( retVal == false )
         {
             break;
         }
     }
 
-    if( retVal != -1 )
+    if( retVal == true )
     {
         *num = out;
     }
@@ -462,7 +462,7 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
 
     if( result == JSONSuccess )
     {
-        if( getNumberFromString( value, fileBlockLength, fileId ) < 0 )
+        if( getNumberFromString( value, fileBlockLength, fileId ) == false )
         {
             handleStatus = MQTTFileDownloaderDataDecodingFailed;
         }
@@ -479,7 +479,7 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
 
         if( result == JSONSuccess )
         {
-            if( getNumberFromString( value, fileBlockLength, blockId ) < 0 )
+            if( getNumberFromString( value, fileBlockLength, blockId ) == false )
             {
                 handleStatus = MQTTFileDownloaderDataDecodingFailed;
             }
@@ -501,7 +501,7 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
 
         if( result == JSONSuccess )
         {
-            if( getNumberFromString( value, fileBlockLength, blockSize ) < 0 )
+            if( getNumberFromString( value, fileBlockLength, blockSize ) == false )
             {
                 handleStatus = MQTTFileDownloaderDataDecodingFailed;
             }

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -84,11 +84,11 @@ static uint16_t createTopic( char * topicBuffer,
  */
 static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
                                                      size_t messageLength,
-													 int32_t * fileId,
-													                                                      int32_t * blockId,
-													                                                      int32_t * blockSize,
-													                                                      uint8_t * decodedData,
-													                                                      size_t * decodedDataLength );
+                                                     int32_t * fileId,
+                                                     int32_t * blockId,
+                                                     int32_t * blockSize,
+                                                     uint8_t * decodedData,
+                                                     size_t * decodedDataLength );
 
 /**
  * @brief Handles and decodes the received message in JSON format.
@@ -103,13 +103,13 @@ static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
  *
  * @return uint8_t returns appropriate MQTT File Downloader Status.
  */
-static MQTTFileDownloaderStatus_t handleJsonMessage(    uint8_t * message,
+static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
                                                      size_t messageLength,
-													 int32_t * fileId,
-													                                                      int32_t * blockId,
-													                                                      int32_t * blockSize,
-													                                                      uint8_t * decodedData,
-													                                                      size_t * decodedDataLength );
+                                                     int32_t * fileId,
+                                                     int32_t * blockId,
+                                                     int32_t * blockSize,
+                                                     uint8_t * decodedData,
+                                                     size_t * decodedDataLength );
 
 /**
  * @brief Handles and decodes the received message in JSON format.
@@ -344,11 +344,11 @@ size_t mqttDownloader_createGetDataBlockRequest( DataType_t dataType,
 
 static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
                                                      size_t messageLength,
-													 int32_t * fileId,
-													                                                      int32_t * blockId,
-													                                                      int32_t * blockSize,
-													                                                      uint8_t * decodedData,
-													                                                      size_t * decodedDataLength )
+                                                     int32_t * fileId,
+                                                     int32_t * blockId,
+                                                     int32_t * blockSize,
+                                                     uint8_t * decodedData,
+                                                     size_t * decodedDataLength )
 {
     bool cborDecodeRet = false;
     uint8_t * payload = decodedData;
@@ -430,11 +430,11 @@ static int32_t getNumberFromString( char * str,
 
 static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
                                                      size_t messageLength,
-													 int32_t * fileId,
-													                                                      int32_t * blockId,
-													                                                      int32_t * blockSize,
-													                                                      uint8_t * decodedData,
-													                                                      size_t * decodedDataLength )
+                                                     int32_t * fileId,
+                                                     int32_t * blockId,
+                                                     int32_t * blockSize,
+                                                     uint8_t * decodedData,
+                                                     size_t * decodedDataLength )
 {
     const char fileIdQuery[] = "f";
     size_t fileIdQueryLength = sizeof( fileIdQuery ) - 1U;
@@ -584,23 +584,23 @@ MQTTFileDownloaderStatus_t mqttDownloader_processReceivedDataBlock( const MqttFi
 
         if( context->dataType == ( uint8_t ) DATA_TYPE_JSON )
         {
-            decodingStatus = handleJsonMessage(                                                 message,
+            decodingStatus = handleJsonMessage( message,
                                                 messageLength,
-												fileId,
-												                                                blockId,
-												                                                blockSize,
-												                                                data,
-												                                                dataLength );
+                                                fileId,
+                                                blockId,
+                                                blockSize,
+                                                data,
+                                                dataLength );
         }
         else
         {
-            decodingStatus = handleCborMessage(                                                 message,
+            decodingStatus = handleCborMessage( message,
                                                 messageLength,
-												fileId,
-												                                                blockId,
-												                                                blockSize,
-												                                                data,
-												                                                dataLength );
+                                                fileId,
+                                                blockId,
+                                                blockSize,
+                                                data,
+                                                dataLength );
         }
     }
 

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -26,8 +26,8 @@
 #include "MQTTFileDownloader_cbor.h"
 #include "core_json.h"
 
-#define IS_CHAR_DIGIT( x )  ( ( ( x ) >= '0' ) && ( ( x ) <= '9' ) )
-#define CHAR_TO_DIGIT( x )  ( ( x ) - '0' )
+#define IS_CHAR_DIGIT( x )    ( ( ( x ) >= '0' ) && ( ( x ) <= '9' ) )
+#define CHAR_TO_DIGIT( x )    ( ( x ) - '0' )
 
 /**
  * @brief Build a string from a set of strings
@@ -350,55 +350,57 @@ static MQTTFileDownloaderStatus_t handleCborMessage( int32_t * fileId,
     return handleStatus;
 }
 
-static int getNumberFromString( char * str, size_t len, int32_t * num )
+static int getNumberFromString( char * str,
+                                size_t len,
+                                int32_t * num )
 {
-	int32_t out = 0;
-	int32_t digit;
-	int retVal = 0;
-	const int32_t maxValue = 2147483647;
+    int32_t out = 0;
+    int32_t digit;
+    int retVal = 0;
+    const int32_t maxValue = 2147483647;
 
-	/* Biggest number which can fit in an int32_t is 2147483647 which has 10 digits. */
-	assert( len <= 10 );
+    /* Biggest number which can fit in an int32_t is 2147483647 which has 10 digits. */
+    assert( len <= 10 );
 
-	for( int i = 0; i < len; i++ )
-	{
-	    if( IS_CHAR_DIGIT( str[ i ] ) != 0 )
-	    {
-	    	digit = CHAR_TO_DIGIT( str[ i ] );
+    for( int i = 0; i < len; i++ )
+    {
+        if( IS_CHAR_DIGIT( str[ i ] ) != 0 )
+        {
+            digit = CHAR_TO_DIGIT( str[ i ] );
 
-	    	if( ( maxValue / 10 ) < out )
-	    	{
-	    		/* The out value will overflow on multiplication with 10. */
-	    		retVal = -1;
-	    	}
-	    	else if( ( maxValue - digit ) < ( out * 10 ) )
-	    	{
-	    		/* The value ( out * 10 ) will overflow when the digit is
-	    		 * added to it. */
-	    		retVal = -1;
-	    	}
-	    	else
-	    	{
-	    	    out = ( out * 10 ) + digit;
-	    	}
-	    }
-	    else
-	    {
-	    	retVal = -1;
-	    }
+            if( ( maxValue / 10 ) < out )
+            {
+                /* The out value will overflow on multiplication with 10. */
+                retVal = -1;
+            }
+            else if( ( maxValue - digit ) < ( out * 10 ) )
+            {
+                /* The value ( out * 10 ) will overflow when the digit is
+                 * added to it. */
+                retVal = -1;
+            }
+            else
+            {
+                out = ( out * 10 ) + digit;
+            }
+        }
+        else
+        {
+            retVal = -1;
+        }
 
-	    if( retVal < 0 )
-	    {
-	    	break;
-	    }
-	}
+        if( retVal < 0 )
+        {
+            break;
+        }
+    }
 
-	if( retVal != -1 )
-	{
-		*num = out;
-	}
+    if( retVal != -1 )
+    {
+        *num = out;
+    }
 
-	return retVal;
+    return retVal;
 }
 
 static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
@@ -409,12 +411,12 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
                                                      uint8_t * message,
                                                      size_t messageLength )
 {
-	const char fileIdQuery[] = "f";
-	size_t fileIdQueryLength = sizeof( fileIdQuery ) - 1U;
-	const char blockIdQuery[] = "i";
-	size_t blockIdQueryLength = sizeof( blockIdQuery ) - 1U;
-	const char blockSizeQuery[] = "l";
-	size_t blockSizeQueryLength = sizeof( blockSizeQuery ) - 1U;
+    const char fileIdQuery[] = "f";
+    size_t fileIdQueryLength = sizeof( fileIdQuery ) - 1U;
+    const char blockIdQuery[] = "i";
+    size_t blockIdQueryLength = sizeof( blockIdQuery ) - 1U;
+    const char blockSizeQuery[] = "l";
+    size_t blockSizeQueryLength = sizeof( blockSizeQuery ) - 1U;
     const char dataQuery[] = "p";
     size_t dataQueryLength = sizeof( dataQuery ) - 1U;
     char * dataValue;
@@ -427,17 +429,17 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
     Base64Status_t base64Status = Base64Success;
 
     result = JSON_Search( ( char * ) message,
-                              messageLength,
-							  fileIdQuery,
-							  fileIdQueryLength,
-							  &value,
-                              &fileBlockLength );
+                          messageLength,
+                          fileIdQuery,
+                          fileIdQueryLength,
+                          &value,
+                          &fileBlockLength );
 
     if( result == JSONSuccess )
     {
-    	if( getNumberFromString( value, fileBlockLength, fileId ) < 0 )
+        if( getNumberFromString( value, fileBlockLength, fileId ) < 0 )
         {
-    	    handleStatus = MQTTFileDownloaderDataDecodingFailed;
+            handleStatus = MQTTFileDownloaderDataDecodingFailed;
         }
     }
 
@@ -449,16 +451,17 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
                               blockIdQueryLength,
                               &value,
                               &fileBlockLength );
+
         if( result == JSONSuccess )
-		{
-			if( getNumberFromString( value, fileBlockLength, blockId ) < 0 )
-			{
-				handleStatus = MQTTFileDownloaderDataDecodingFailed;
-			}
-		}
+        {
+            if( getNumberFromString( value, fileBlockLength, blockId ) < 0 )
+            {
+                handleStatus = MQTTFileDownloaderDataDecodingFailed;
+            }
+        }
         else
         {
-        	handleStatus = MQTTFileDownloaderDataDecodingFailed;
+            handleStatus = MQTTFileDownloaderDataDecodingFailed;
         }
     }
 
@@ -470,17 +473,18 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
                               blockSizeQueryLength,
                               &value,
                               &fileBlockLength );
+
         if( result == JSONSuccess )
-		{
-			if( getNumberFromString( value, fileBlockLength, blockSize ) < 0 )
-			{
-				handleStatus = MQTTFileDownloaderDataDecodingFailed;
-			}
-		}
-		else
-		{
-			handleStatus = MQTTFileDownloaderDataDecodingFailed;
-		}
+        {
+            if( getNumberFromString( value, fileBlockLength, blockSize ) < 0 )
+            {
+                handleStatus = MQTTFileDownloaderDataDecodingFailed;
+            }
+        }
+        else
+        {
+            handleStatus = MQTTFileDownloaderDataDecodingFailed;
+        }
     }
 
     if( handleStatus = MQTTFileDownloaderSuccess )
@@ -491,10 +495,11 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
                               dataQueryLength,
                               &dataValue,
                               &dataValueLength );
+
         if( result != JSONSuccess )
-		{
-			handleStatus = MQTTFileDownloaderDataDecodingFailed;
-		}
+        {
+            handleStatus = MQTTFileDownloaderDataDecodingFailed;
+        }
     }
 
     if( handleStatus == MQTTFileDownloaderSuccess )
@@ -566,8 +571,8 @@ MQTTFileDownloaderStatus_t mqttDownloader_processReceivedDataBlock( const MqttFi
         {
             decodingStatus = handleCborMessage( fileId,
                                                 blockId,
-												blockSize,
-												data,
+                                                blockSize,
+                                                data,
                                                 dataLength,
                                                 message,
                                                 messageLength );

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -74,11 +74,11 @@ static uint16_t createTopic( char * topicBuffer,
  *
  * @param[in] message Incoming MQTT message received.
  * @param[in] messageLength Length of the MQTT message received.
- * @param[out] decodedData Buffer to place the decoded data in.
- * @param[out] decodedDataLength Length of decoded data.
  * @param[out] fileId ID of the file to which the data block belongs.
  * @param[out] blockId ID of the received block.
  * @param[out] blockSize Size of the receive block in bytes.
+ * @param[out] decodedData Buffer to place the decoded data in.
+ * @param[out] decodedDataLength Length of decoded data.
  *
  * @return uint8_t returns appropriate MQTT File Downloader Status.
  */

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -468,7 +468,7 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
         }
     }
 
-    if( handleStatus = MQTTFileDownloaderSuccess )
+    if( handleStatus == MQTTFileDownloaderSuccess )
     {
         result = JSON_Search( ( char * ) message,
                               messageLength,
@@ -490,7 +490,7 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
         }
     }
 
-    if( handleStatus = MQTTFileDownloaderSuccess )
+    if( handleStatus == MQTTFileDownloaderSuccess )
     {
         result = JSON_Search( ( char * ) message,
                               messageLength,
@@ -512,7 +512,7 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
         }
     }
 
-    if( handleStatus = MQTTFileDownloaderSuccess )
+    if( handleStatus == MQTTFileDownloaderSuccess )
     {
         result = JSON_Search( ( char * ) message,
                               messageLength,

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -26,7 +26,14 @@
 #include "MQTTFileDownloader_cbor.h"
 #include "core_json.h"
 
+/**
+ * @brief Macro to check whether a character is an ASCII digit or not.
+ */
 #define IS_CHAR_DIGIT( x )    ( ( ( x ) >= '0' ) && ( ( x ) <= '9' ) )
+
+/**
+ * @brief Macro to convert an ASCII digit to integer.
+ */
 #define CHAR_TO_DIGIT( x )    ( ( x ) - '0' )
 
 /**
@@ -103,6 +110,24 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
                                                      size_t * decodedDataLength,
                                                      uint8_t * message,
                                                      size_t messageLength );
+
+/**
+ * @brief Handles and decodes the received message in JSON format.
+ *
+ * @param[in] str String which has the ASCII representation of the
+ *            number.
+ * @param[in] len Length of the string.
+ * @param[out] num Pointer to an int32_t variable which will be filled
+ *            with the parsed value. If the return value of the function
+ *            call is -1, then the value present in num is invalid.
+ *
+ * @return int32_t if the string is malformed or the decoded number
+ * cannot fit in an int32_t value then this function returns -1. On
+ * successful parsing, it returns 0.
+ */
+static int32_t getNumberFromString( char * str,
+                                    size_t len,
+                                    int32_t * num );
 
 static size_t stringBuilder( char * buffer,
                              size_t bufferSizeBytes,
@@ -350,9 +375,9 @@ static MQTTFileDownloaderStatus_t handleCborMessage( int32_t * fileId,
     return handleStatus;
 }
 
-static int getNumberFromString( char * str,
-                                size_t len,
-                                int32_t * num )
+static int32_t getNumberFromString( char * str,
+                                    size_t len,
+                                    int32_t * num )
 {
     int32_t out = 0;
     int32_t digit;

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -82,13 +82,13 @@ static uint16_t createTopic( char * topicBuffer,
  *
  * @return uint8_t returns appropriate MQTT File Downloader Status.
  */
-static MQTTFileDownloaderStatus_t handleCborMessage( int32_t * fileId,
-                                                     int32_t * blockId,
-                                                     int32_t * blockSize,
-                                                     uint8_t * decodedData,
-                                                     size_t * decodedDataLength,
-                                                     const uint8_t * message,
-                                                     size_t messageLength );
+static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
+                                                     size_t messageLength,
+													 int32_t * fileId,
+													                                                      int32_t * blockId,
+													                                                      int32_t * blockSize,
+													                                                      uint8_t * decodedData,
+													                                                      size_t * decodedDataLength );
 
 /**
  * @brief Handles and decodes the received message in JSON format.
@@ -103,13 +103,13 @@ static MQTTFileDownloaderStatus_t handleCborMessage( int32_t * fileId,
  *
  * @return uint8_t returns appropriate MQTT File Downloader Status.
  */
-static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
-                                                     int32_t * blockId,
-                                                     int32_t * blockSize,
-                                                     uint8_t * decodedData,
-                                                     size_t * decodedDataLength,
-                                                     uint8_t * message,
-                                                     size_t messageLength );
+static MQTTFileDownloaderStatus_t handleJsonMessage(    uint8_t * message,
+                                                     size_t messageLength,
+													 int32_t * fileId,
+													                                                      int32_t * blockId,
+													                                                      int32_t * blockSize,
+													                                                      uint8_t * decodedData,
+													                                                      size_t * decodedDataLength );
 
 /**
  * @brief Handles and decodes the received message in JSON format.
@@ -342,13 +342,13 @@ size_t mqttDownloader_createGetDataBlockRequest( DataType_t dataType,
     return requestLength;
 }
 
-static MQTTFileDownloaderStatus_t handleCborMessage( int32_t * fileId,
-                                                     int32_t * blockId,
-                                                     int32_t * blockSize,
-                                                     uint8_t * decodedData,
-                                                     size_t * decodedDataLength,
-                                                     const uint8_t * message,
-                                                     size_t messageLength )
+static MQTTFileDownloaderStatus_t handleCborMessage( const uint8_t * message,
+                                                     size_t messageLength,
+													 int32_t * fileId,
+													                                                      int32_t * blockId,
+													                                                      int32_t * blockSize,
+													                                                      uint8_t * decodedData,
+													                                                      size_t * decodedDataLength )
 {
     bool cborDecodeRet = false;
     uint8_t * payload = decodedData;
@@ -428,13 +428,13 @@ static int32_t getNumberFromString( char * str,
     return retVal;
 }
 
-static MQTTFileDownloaderStatus_t handleJsonMessage( int32_t * fileId,
-                                                     int32_t * blockId,
-                                                     int32_t * blockSize,
-                                                     uint8_t * decodedData,
-                                                     size_t * decodedDataLength,
-                                                     uint8_t * message,
-                                                     size_t messageLength )
+static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
+                                                     size_t messageLength,
+													 int32_t * fileId,
+													                                                      int32_t * blockId,
+													                                                      int32_t * blockSize,
+													                                                      uint8_t * decodedData,
+													                                                      size_t * decodedDataLength )
 {
     const char fileIdQuery[] = "f";
     size_t fileIdQueryLength = sizeof( fileIdQuery ) - 1U;
@@ -584,23 +584,23 @@ MQTTFileDownloaderStatus_t mqttDownloader_processReceivedDataBlock( const MqttFi
 
         if( context->dataType == ( uint8_t ) DATA_TYPE_JSON )
         {
-            decodingStatus = handleJsonMessage( fileId,
-                                                blockId,
-                                                blockSize,
-                                                data,
-                                                dataLength,
-                                                message,
-                                                messageLength );
+            decodingStatus = handleJsonMessage(                                                 message,
+                                                messageLength,
+												fileId,
+												                                                blockId,
+												                                                blockSize,
+												                                                data,
+												                                                dataLength );
         }
         else
         {
-            decodingStatus = handleCborMessage( fileId,
-                                                blockId,
-                                                blockSize,
-                                                data,
-                                                dataLength,
-                                                message,
-                                                messageLength );
+            decodingStatus = handleCborMessage(                                                 message,
+                                                messageLength,
+												fileId,
+												                                                blockId,
+												                                                blockSize,
+												                                                data,
+												                                                dataLength );
         }
     }
 

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -449,7 +449,7 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
     size_t fileBlockLength;
     char * value;
     JSONStatus_t result = JSONSuccess;
-    MQTTFileDownloaderStatus_t handleStatus = MQTTFileDownloaderSuccess;
+    MQTTFileDownloaderStatus_t handleStatus = MQTTFileDownloaderDataDecodingFailed;
 
     Base64Status_t base64Status = Base64Success;
 
@@ -462,9 +462,9 @@ static MQTTFileDownloaderStatus_t handleJsonMessage( uint8_t * message,
 
     if( result == JSONSuccess )
     {
-        if( getNumberFromString( value, fileBlockLength, fileId ) == false )
+        if( getNumberFromString( value, fileBlockLength, fileId ) == true )
         {
-            handleStatus = MQTTFileDownloaderDataDecodingFailed;
+            handleStatus = MQTTFileDownloaderSuccess;
         }
     }
 
@@ -578,7 +578,10 @@ MQTTFileDownloaderStatus_t mqttDownloader_processReceivedDataBlock( const MqttFi
 {
     MQTTFileDownloaderStatus_t decodingStatus = MQTTFileDownloaderFailure;
 
-    if( ( message != NULL ) && ( messageLength != 0U ) && ( data != NULL ) && ( dataLength != NULL ) )
+    if( ( message != NULL ) && ( messageLength != 0U ) &&
+        ( data != NULL ) && ( dataLength != NULL ) &&
+        ( fileId != NULL ) && ( blockId != NULL ) &&
+        ( blockSize != NULL ) )
     {
         ( void ) memset( data, ( int32_t ) '\0', mqttFileDownloader_CONFIG_BLOCK_SIZE );
 

--- a/source/include/MQTTFileDownloader.h
+++ b/source/include/MQTTFileDownloader.h
@@ -190,11 +190,11 @@ MQTTFileDownloaderStatus_t mqttDownloader_isDataBlockReceived( const MqttFileDow
  * @param[in] context MQTT file downloader context pointer.
  * @param[in] message Incoming MQTT message containing data block.
  * @param[in] messageLength Incoming MQTT message length.
- * @param[out] data Decoded data block.
- * @param[in] dataLength Decoded data block length.
  * @param[out] fileId ID of the file to which the data block belongs.
  * @param[out] blockId ID of the received block.
  * @param[out] blockSize Size of the receive block in bytes.
+ * @param[out] data Decoded data block.
+ * @param[in] dataLength Decoded data block length.
  *
  * @return returns True if the message is handled else False.
  */

--- a/source/include/MQTTFileDownloader.h
+++ b/source/include/MQTTFileDownloader.h
@@ -192,6 +192,9 @@ MQTTFileDownloaderStatus_t mqttDownloader_isDataBlockReceived( const MqttFileDow
  * @param[in] messageLength Incoming MQTT message length.
  * @param[out] data Decoded data block.
  * @param[in] dataLength Decoded data block length.
+ * @param[out] fileId ID of the file to which the data block belongs.
+ * @param[out] blockId ID of the received block.
+ * @param[out] blockSize Size of the receive block in bytes.
  *
  * @return returns True if the message is handled else False.
  */

--- a/source/include/MQTTFileDownloader.h
+++ b/source/include/MQTTFileDownloader.h
@@ -199,6 +199,9 @@ MQTTFileDownloaderStatus_t mqttDownloader_isDataBlockReceived( const MqttFileDow
 MQTTFileDownloaderStatus_t mqttDownloader_processReceivedDataBlock( const MqttFileDownloaderContext_t * context,
                                                                     uint8_t * message,
                                                                     size_t messageLength,
+                                                                    int32_t * fileId,
+                                                                    int32_t * blockId,
+                                                                    int32_t * blockSize,
                                                                     uint8_t * data,
                                                                     size_t * dataLength );
 /* @[declare_mqttDownloader_processReceivedDataBlock] */

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -407,7 +407,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeIsTooBig( void )
 
     const char * message2 = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"2147483649\", \"p\": \"dGVzdA==\"}";
 
-    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message2, strlen( message2 ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+    result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message2, strlen( message2 ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( 7, result );
     TEST_ASSERT_EQUAL( 0, fileId );

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -298,7 +298,7 @@ void test_processReceivedDataBlock_processesJSONBlock( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -320,7 +320,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_fileIdNotANumber( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -342,7 +342,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockIdNotANumber( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -364,7 +364,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeNotANumber( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -386,7 +386,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeNegative( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -408,7 +408,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_fileIdNegative( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -430,7 +430,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockIdNegative( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -454,7 +454,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeIsTooBig( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -489,7 +489,7 @@ void test_processReceivedDataBlock_invalidJSONBlock( void )
     const char * message = "{\"wrongKey\": \"dGVzdA==\"}";
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -510,7 +510,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_fileIdNotPresent( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -532,7 +532,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_blockIdNotPresent( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -554,7 +554,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_blockSizeNotPresent( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -576,7 +576,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_payloadNotPresent( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -598,7 +598,7 @@ void test_processReceivedDataBlock_invalidEncodingJSONBlock( void )
     context.dataType = DATA_TYPE_JSON;
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -622,7 +622,7 @@ void test_processReceivedDataBlock_processesCBORBlock( void )
     char * validCBORMsg = "aValidCBORMsg";
     size_t expectedProcessedDataLength = 12345U;
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -659,7 +659,7 @@ void test_processReceivedDataBlock_invalidCBORBlock( void )
     char * invalidCBORMsg = "invalidCBORMsg";
     size_t notExpectedProcessedDataLength = 12345U;
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -690,7 +690,7 @@ void test_processReceivedDataBlock_returnsFailureWhenMessageIsNull( void )
     const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -712,7 +712,7 @@ void test_processReceivedDataBlock_returnsFailureWhenMessageLengthZero( void )
     const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -733,7 +733,7 @@ void test_processReceivedDataBlock_returnsFailureWhenDataIsNull( void )
 
     const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
@@ -773,7 +773,7 @@ void test_processReceivedDataBlock_returnsFailureWhenFileIdIsNull( void )
     const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
@@ -793,7 +793,7 @@ void test_processReceivedDataBlock_returnsFailureWhenBlockIdIsNull( void )
     const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockSize = 0;
 
@@ -813,7 +813,7 @@ void test_processReceivedDataBlock_returnsFailureWhenBlockSizeIsNull( void )
     const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
-    size_t dataLength = 0;
+    size_t dataLength = 0U;
     int32_t fileId = 0;
     int32_t blockId = 0;
 

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -394,7 +394,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeIsTooBig( void )
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
-    
+
     const char * message1 = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"5147483647\", \"p\": \"dGVzdA==\"}";
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message1, strlen( message1 ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
@@ -664,7 +664,7 @@ void test_processReceivedDataBlock_returnsFailureWhenDataIsNull( void )
     size_t dataLength = 0;
     int32_t fileId = 0;
     int32_t blockId = 0;
-    int32_t blockSize = 0;    
+    int32_t blockSize = 0;
 
     uintResult = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"p\": \"dGVzdA==\"}", strlen( "{\"p\": \"dGVzdA==\"}" ), &fileId, &blockId, &blockSize, NULL, &dataLength );
     TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -29,14 +29,12 @@ size_t streamNameLength = strlen( "stream-name" );
 char * getStreamTopic = "get-stream-topic";
 size_t getStreamTopicLength = strlen( "get-stream-topic" );
 
-uint8_t uintResult;
 size_t requestLength;
 /* ===========================   UNITY FIXTURES ============================ */
 
 /* Called before each test method. */
 void setUp()
 {
-    uintResult = 10; /* An unimplemented MQTTFileDownloaderStatus value */
 }
 
 /* Called after each test method. */
@@ -120,9 +118,9 @@ void test_init_returnsSuccess_forJSONDataType( void )
 {
     MqttFileDownloaderContext_t context;
 
-    uintResult = mqttDownloader_init( &context, streamName, streamNameLength, thingName, thingNameLength, DATA_TYPE_JSON );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_init( &context, streamName, streamNameLength, thingName, thingNameLength, DATA_TYPE_JSON );
 
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderSuccess, uintResult );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderSuccess, result );
     TEST_ASSERT_EQUAL_MEMORY( "$aws/things/thingname/streams/stream-name/data/json", context.topicStreamData, strlen( "$aws/things/thingname/streams/stream-name/data/json" ) );
     TEST_ASSERT_EQUAL_INT( strlen( "$aws/things/thingname/streams/stream-name/data/json" ), context.topicStreamDataLength );
     TEST_ASSERT_EQUAL_MEMORY( "$aws/things/thingname/streams/stream-name/get/json", context.topicGetStream, strlen( "$aws/things/thingname/streams/stream-name/get/json" ) );
@@ -133,9 +131,9 @@ void test_init_returnsSuccess_forCBORDataType( void )
 {
     MqttFileDownloaderContext_t context;
 
-    uintResult = mqttDownloader_init( &context, streamName, streamNameLength, thingName, thingNameLength, DATA_TYPE_CBOR );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_init( &context, streamName, streamNameLength, thingName, thingNameLength, DATA_TYPE_CBOR );
 
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderSuccess, uintResult );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderSuccess, result );
     TEST_ASSERT_EQUAL_MEMORY( "$aws/things/thingname/streams/stream-name/data/cbor", context.topicStreamData, strlen( "$aws/things/thingname/streams/stream-name/data/cbor" ) );
     TEST_ASSERT_EQUAL_INT( strlen( "$aws/things/thingname/streams/stream-name/data/cbor" ), context.topicStreamDataLength );
     TEST_ASSERT_EQUAL_MEMORY( "$aws/things/thingname/streams/stream-name/get/cbor", context.topicGetStream, strlen( "$aws/things/thingname/streams/stream-name/get/cbor" ) );
@@ -144,45 +142,45 @@ void test_init_returnsSuccess_forCBORDataType( void )
 
 void test_init_returnsBadParam_givenNullContext( void )
 {
-    uintResult = mqttDownloader_init( NULL, streamName, streamNameLength, thingName, thingNameLength, DATA_TYPE_JSON );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_init( NULL, streamName, streamNameLength, thingName, thingNameLength, DATA_TYPE_JSON );
 
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, uintResult );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, result );
 }
 
 void test_init_returnsBadParam_givenNullStreamName( void )
 {
     MqttFileDownloaderContext_t context = { 0 };
 
-    uintResult = mqttDownloader_init( &context, NULL, streamNameLength, thingName, thingNameLength, DATA_TYPE_JSON );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_init( &context, NULL, streamNameLength, thingName, thingNameLength, DATA_TYPE_JSON );
 
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, uintResult );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, result );
 }
 
 void test_init_returnsBadParam_givenZeroStreamNameLength( void )
 {
     MqttFileDownloaderContext_t context = { 0 };
 
-    uintResult = mqttDownloader_init( &context, streamName, 0, thingName, thingNameLength, DATA_TYPE_JSON );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_init( &context, streamName, 0, thingName, thingNameLength, DATA_TYPE_JSON );
 
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, uintResult );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, result );
 }
 
 void test_init_returnsBadParam_givenNullThingName( void )
 {
     MqttFileDownloaderContext_t context = { 0 };
 
-    uintResult = mqttDownloader_init( &context, streamName, streamNameLength, NULL, thingNameLength, DATA_TYPE_JSON );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_init( &context, streamName, streamNameLength, NULL, thingNameLength, DATA_TYPE_JSON );
 
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, uintResult );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, result );
 }
 
 void test_init_returnsBadParam_givenZeroThingNameLength( void )
 {
     MqttFileDownloaderContext_t context = { 0 };
 
-    uintResult = mqttDownloader_init( &context, streamName, streamNameLength, thingName, 0, DATA_TYPE_JSON );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_init( &context, streamName, streamNameLength, thingName, 0, DATA_TYPE_JSON );
 
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, uintResult );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderBadParameter, result );
 }
 
 void test_createGetDataBlockRequest_succeedsForJSONDataType( void )
@@ -330,7 +328,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_fileIdNotANumber( void )
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
@@ -352,7 +350,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockIdNotANumber( void )
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
@@ -374,9 +372,75 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeNotANumber( void )
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 10, fileId );
     TEST_ASSERT_EQUAL( 1, blockId );
+    TEST_ASSERT_EQUAL( 0, blockSize );
+    TEST_ASSERT_EQUAL( 0, dataLength );
+}
+
+void test_processReceivedDataBlock__invalidJSONBlock_blockSizeNegative( void )
+{
+    MqttFileDownloaderContext_t context = { 0 };
+
+    context.dataType = DATA_TYPE_JSON;
+
+    uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
+    size_t dataLength = 0;
+    int32_t fileId = 0;
+    int32_t blockId = 0;
+    int32_t blockSize = 0;
+    const char * message = "{\"f\": \"10\", \"i\": \"1\", \"l\": \"-123\", \"p\": \"dGVzdA==\"}";
+
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
+    TEST_ASSERT_EQUAL( 10, fileId );
+    TEST_ASSERT_EQUAL( 1, blockId );
+    TEST_ASSERT_EQUAL( 0, blockSize );
+    TEST_ASSERT_EQUAL( 0, dataLength );
+}
+
+void test_processReceivedDataBlock__invalidJSONBlock_fileIdNegative( void )
+{
+    MqttFileDownloaderContext_t context = { 0 };
+
+    context.dataType = DATA_TYPE_JSON;
+
+    uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
+    size_t dataLength = 0;
+    int32_t fileId = 0;
+    int32_t blockId = 0;
+    int32_t blockSize = 0;
+    const char * message = "{\"f\": \"-10\", \"i\": \"1\", \"l\": \"16\", \"p\": \"dGVzdA==\"}";
+
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
+    TEST_ASSERT_EQUAL( 0, fileId );
+    TEST_ASSERT_EQUAL( 0, blockId );
+    TEST_ASSERT_EQUAL( 0, blockSize );
+    TEST_ASSERT_EQUAL( 0, dataLength );
+}
+
+void test_processReceivedDataBlock__invalidJSONBlock_blockIdNegative( void )
+{
+    MqttFileDownloaderContext_t context = { 0 };
+
+    context.dataType = DATA_TYPE_JSON;
+
+    uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
+    size_t dataLength = 0;
+    int32_t fileId = 0;
+    int32_t blockId = 0;
+    int32_t blockSize = 0;
+    const char * message = "{\"f\": \"10\", \"i\": \"-11\", \"l\": \"12\", \"p\": \"dGVzdA==\"}";
+
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
+    TEST_ASSERT_EQUAL( 10, fileId );
+    TEST_ASSERT_EQUAL( 0, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
     TEST_ASSERT_EQUAL( 0, dataLength );
 }
@@ -399,7 +463,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeIsTooBig( void )
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message1, strlen( message1 ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 20, fileId );
     TEST_ASSERT_EQUAL( 56, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
@@ -409,7 +473,7 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeIsTooBig( void )
 
     result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message2, strlen( message2 ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 20, fileId );
     TEST_ASSERT_EQUAL( 56, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
@@ -422,15 +486,17 @@ void test_processReceivedDataBlock_invalidJSONBlock( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"wrongKey\": \"dGVzdA==\"}";
+
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t dataLength = 0;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
-    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"wrongKey\": \"dGVzdA==\"}", strlen( "{\"wrongKey\": \"dGVzdA==\"}" ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
@@ -540,7 +606,7 @@ void test_processReceivedDataBlock_invalidEncodingJSONBlock( void )
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 12, fileId );
     TEST_ASSERT_EQUAL( 1, blockId );
     TEST_ASSERT_EQUAL( 512, blockSize );
@@ -608,7 +674,7 @@ void test_processReceivedDataBlock_invalidCBORBlock( void )
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) invalidCBORMsg, strlen( invalidCBORMsg ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
-    TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 0, dataLength );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );
@@ -621,14 +687,16 @@ void test_processReceivedDataBlock_returnsFailureWhenMessageIsNull( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
+
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t dataLength = 0;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
-    uintResult = mqttDownloader_processReceivedDataBlock( &context, NULL, strlen( "{\"p\": \"dGVzdA==\"}" ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, NULL, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, result );
     TEST_ASSERT_EQUAL( 0, dataLength );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );
@@ -641,14 +709,16 @@ void test_processReceivedDataBlock_returnsFailureWhenMessageLengthZero( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
+
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t dataLength = 0;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
-    uintResult = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"p\": \"dGVzdA==\"}", 0U, &fileId, &blockId, &blockSize, decodedData, &dataLength );
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, 0U, &fileId, &blockId, &blockSize, decodedData, &dataLength );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, result );
     TEST_ASSERT_EQUAL( 0, dataLength );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );
@@ -661,13 +731,15 @@ void test_processReceivedDataBlock_returnsFailureWhenDataIsNull( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
+
     size_t dataLength = 0;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
-    uintResult = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"p\": \"dGVzdA==\"}", strlen( "{\"p\": \"dGVzdA==\"}" ), &fileId, &blockId, &blockSize, NULL, &dataLength );
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, NULL, &dataLength );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, result );
     TEST_ASSERT_EQUAL( 0, dataLength );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );
@@ -680,14 +752,16 @@ void test_processReceivedDataBlock_returnsFailureWhenDataLengthIsNull( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
+
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t * dataLength = NULL;
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
-    uintResult = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"p\": \"dGVzdA==\"}", strlen( "{\"p\": \"dGVzdA==\"}" ), &fileId, &blockId, &blockSize, decodedData, dataLength );
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, dataLength );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, result );
 }
 
 void test_processReceivedDataBlock_returnsFailureWhenFileIdIsNull( void )
@@ -696,13 +770,15 @@ void test_processReceivedDataBlock_returnsFailureWhenFileIdIsNull( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
+
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t dataLength = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
-    uintResult = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"p\": \"dGVzdA==\"}", strlen( "{\"p\": \"dGVzdA==\"}" ), NULL, &blockId, &blockSize, decodedData, &dataLength );
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), NULL, &blockId, &blockSize, decodedData, &dataLength );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, result );
     TEST_ASSERT_EQUAL( 0, dataLength );
     TEST_ASSERT_EQUAL( 0, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
@@ -714,13 +790,15 @@ void test_processReceivedDataBlock_returnsFailureWhenBlockIdIsNull( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
+
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t dataLength = 0;
     int32_t fileId = 0;
     int32_t blockSize = 0;
 
-    uintResult = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"p\": \"dGVzdA==\"}", strlen( "{\"p\": \"dGVzdA==\"}" ), &fileId, NULL, &blockSize, decodedData, &dataLength );
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, NULL, &blockSize, decodedData, &dataLength );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, result );
     TEST_ASSERT_EQUAL( 0, dataLength );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockSize );
@@ -732,13 +810,15 @@ void test_processReceivedDataBlock_returnsFailureWhenBlockSizeIsNull( void )
 
     context.dataType = DATA_TYPE_JSON;
 
+    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
+
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t dataLength = 0;
     int32_t fileId = 0;
     int32_t blockId = 0;
 
-    uintResult = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"p\": \"dGVzdA==\"}", strlen( "{\"p\": \"dGVzdA==\"}" ), &fileId, &blockId, NULL, decodedData, &dataLength );
-    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, uintResult );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, NULL, decodedData, &dataLength );
+    TEST_ASSERT_EQUAL( MQTTFileDownloaderFailure, result );
     TEST_ASSERT_EQUAL( 0, dataLength );
     TEST_ASSERT_EQUAL( 0, fileId );
     TEST_ASSERT_EQUAL( 0, blockId );

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -370,13 +370,13 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeNotANumber( void )
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
-    const char * message = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"size\", \"p\": \"dGVzdA==\"}";
+    const char * message = "{\"f\": \"10\", \"i\": \"1\", \"l\": \"size\", \"p\": \"dGVzdA==\"}";
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( 7, result );
-    TEST_ASSERT_EQUAL( 0, fileId );
-    TEST_ASSERT_EQUAL( 0, blockId );
+    TEST_ASSERT_EQUAL( 10, fileId );
+    TEST_ASSERT_EQUAL( 1, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
     TEST_ASSERT_EQUAL( 0, dataLength );
 }
@@ -395,23 +395,23 @@ void test_processReceivedDataBlock__invalidJSONBlock_blockSizeIsTooBig( void )
     int32_t blockId = 0;
     int32_t blockSize = 0;
 
-    const char * message1 = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"5147483647\", \"p\": \"dGVzdA==\"}";
+    const char * message1 = "{\"f\": \"20\", \"i\": \"56\", \"l\": \"5147483647\", \"p\": \"dGVzdA==\"}";
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message1, strlen( message1 ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( 7, result );
-    TEST_ASSERT_EQUAL( 0, fileId );
-    TEST_ASSERT_EQUAL( 0, blockId );
+    TEST_ASSERT_EQUAL( 20, fileId );
+    TEST_ASSERT_EQUAL( 56, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
     TEST_ASSERT_EQUAL( 0, dataLength );
 
-    const char * message2 = "{\"f\": \"0\", \"i\": \"1\", \"l\": \"2147483649\", \"p\": \"dGVzdA==\"}";
+    const char * message2 = "{\"f\": \"20\", \"i\": \"56\", \"l\": \"2147483649\", \"p\": \"dGVzdA==\"}";
 
     result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message2, strlen( message2 ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( 7, result );
-    TEST_ASSERT_EQUAL( 0, fileId );
-    TEST_ASSERT_EQUAL( 0, blockId );
+    TEST_ASSERT_EQUAL( 20, fileId );
+    TEST_ASSERT_EQUAL( 56, blockId );
     TEST_ASSERT_EQUAL( 0, blockSize );
     TEST_ASSERT_EQUAL( 0, dataLength );
 }
@@ -521,7 +521,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_payloadNotPresent( void )
     TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 1, fileId );
     TEST_ASSERT_EQUAL( 12, blockId );
-    TEST_ASSERT_EQUAL( 0, blockSize );
+    TEST_ASSERT_EQUAL( 512, blockSize );
     TEST_ASSERT_EQUAL( 0, dataLength );
 }
 

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -323,10 +323,16 @@ void test_processReceivedDataBlock_invalidJSONBlock( void )
 
     uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
     size_t dataLength = 0;
+    int32_t fileId = 0;
+    int32_t blockId = 0;
+    int32_t blockSize = 0;
 
-    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"wrongKey\": \"dGVzdA==\"}", strlen( "{\"wrongKey\": \"dGVzdA==\"}" ), decodedData, &dataLength );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) "{\"wrongKey\": \"dGVzdA==\"}", strlen( "{\"wrongKey\": \"dGVzdA==\"}" ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( 7, result );
+    TEST_ASSERT_EQUAL( 0, fileId );
+    TEST_ASSERT_EQUAL( 0, blockId );
+    TEST_ASSERT_EQUAL( 0, blockSize );
     TEST_ASSERT_EQUAL( 0, dataLength );
 }
 
@@ -407,7 +413,7 @@ void test_processReceivedDataBlock_invalidEncodingJSONBlock( void )
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
-    const char * message = "{\"f\": \"12\", \"i\": \"1\", \"l\": \"512\", \"p\": \"notEncoded\"}"
+    const char * message = "{\"f\": \"12\", \"i\": \"1\", \"l\": \"512\", \"p\": \"notEncoded\"}";
 
     MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -349,7 +349,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_fileIdNotPresent( void )
     int32_t blockSize = 0;
     const char * message = "{\"i\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
-    bool result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 0, fileId );
@@ -371,7 +371,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_blockIdNotPresent( void )
     int32_t blockSize = 0;
     const char * message = "{\"f\": \"1\", \"l\": \"512\", \"p\": \"dGVzdA==\"}";
 
-    bool result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 1, fileId );
@@ -393,7 +393,7 @@ void test_processReceivedDataBlock_invalidJSONBlock_blockSizeNotPresent( void )
     int32_t blockSize = 0;
     const char * message = "{\"f\": \"1\", \"i\": \"12\", \"p\": \"dGVzdA==\"}";
 
-    bool result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
+    MQTTFileDownloaderStatus_t result = mqttDownloader_processReceivedDataBlock( &context, ( uint8_t * ) message, strlen( message ), &fileId, &blockId, &blockSize, decodedData, &dataLength );
 
     TEST_ASSERT_EQUAL( MQTTFileDownloaderDataDecodingFailed, result );
     TEST_ASSERT_EQUAL( 1, fileId );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the `mqttDownloader_processReceivedDataBlock` API so that it can return the fileId, blockId and blockSize to the caller.

To that end, this PR also adds string -> int32_t conversion function called `getNumberFromString` as coreJSON only returns the pointer to the location of the value corresponding to the key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
