### PR TITLE
Fix warning in unit tests and memory check tests

### DIFF
--- a/source/MQTTFileDownloader_cbor.c
+++ b/source/MQTTFileDownloader_cbor.c
@@ -114,7 +114,7 @@ bool CBOR_Decode_GetStreamResponseMessage( const uint8_t * messageBuffer,
 
     if( CborNoError == cborResult )
     {
-        cborResult = cbor_value_get_int( &value, ( int32_t * ) fileId );
+        cborResult = cbor_value_get_int( &value, ( int * ) fileId );
     }
 
     /* Find the block ID. */
@@ -132,7 +132,7 @@ bool CBOR_Decode_GetStreamResponseMessage( const uint8_t * messageBuffer,
 
     if( CborNoError == cborResult )
     {
-        cborResult = cbor_value_get_int( &value, ( int32_t * ) blockId );
+        cborResult = cbor_value_get_int( &value, ( int * ) blockId );
     }
 
     /* Find the block size. */
@@ -150,7 +150,7 @@ bool CBOR_Decode_GetStreamResponseMessage( const uint8_t * messageBuffer,
 
     if( CborNoError == cborResult )
     {
-        cborResult = cbor_value_get_int( &value, ( int32_t * ) blockSize );
+        cborResult = cbor_value_get_int( &value, ( int * ) blockSize );
     }
 
     /* Find the payload bytes. */

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -626,9 +626,9 @@ void test_processReceivedDataBlock_processesCBORBlock( void )
     int32_t fileId = 0;
     int32_t blockId = 0;
     int32_t blockSize = 0;
-    const int32_t expectedFileId = 20;
-    const int32_t expectedBlockId = 30;
-    const int32_t expectedBlockSize = 40;
+    int32_t expectedFileId = 20;
+    int32_t expectedBlockId = 30;
+    int32_t expectedBlockSize = 40;
 
     CBOR_Decode_GetStreamResponseMessage_ExpectAndReturn( ( const uint8_t * ) validCBORMsg, strlen( validCBORMsg ), NULL, NULL, NULL, NULL, NULL, true );
     CBOR_Decode_GetStreamResponseMessage_IgnoreArg_fileId();


### PR DESCRIPTION
*Issue #, if available:*

The PR addresses some warnings encountered when running the unit tests and memory check tests.

*Description of changes:*
Unit tests
```
cmake -S ../test
make all
ctest
```
Before applying this patch, the issue encountered

```
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/test/unit-test/downloader_utest.c: In function ‘test_processReceivedDataBlock_processesCBORBlock’:
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/test/unit-test/downloader_utest.c:639:64: warning: passing argument 2 of ‘CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_fileId’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  639 |     CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_fileId( &expectedFileId );
      |                                                                ^~~~~~~~~~~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/build/unit-test/mocks/mock_MQTTFileDownloader_cbor.h:47:151: note: in definition of macro ‘CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_fileId’
   47 | #define CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_fileId(fileId) CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_fileId(__LINE__, fileId, sizeof(int32_t))
      |                                                                                                                                                       ^~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/build/unit-test/mocks/mock_MQTTFileDownloader_cbor.h:50:109: note: expected ‘int32_t *’ {aka ‘int *’} but argument is of type ‘const int32_t *’ {aka ‘const int *’}
   50 | void CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_fileId(UNITY_LINE_TYPE cmock_line, int32_t* fileId, size_t cmock_size);
      |                                                                                                    ~~~~~~~~~^~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/test/unit-test/downloader_utest.c:640:65: warning: passing argument 2 of ‘CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_blockId’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  640 |     CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_blockId( &expectedBlockId );
      |                                                                 ^~~~~~~~~~~~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/build/unit-test/mocks/mock_MQTTFileDownloader_cbor.h:51:154: note: in definition of macro ‘CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_blockId’
   51 | #define CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_blockId(blockId) CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_blockId(__LINE__, blockId, sizeof(int32_t))
      |                                                                                                                                                          ^~~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/build/unit-test/mocks/mock_MQTTFileDownloader_cbor.h:54:110: note: expected ‘int32_t *’ {aka ‘int *’} but argument is of type ‘const int32_t *’ {aka ‘const int *’}
   54 | void CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_blockId(UNITY_LINE_TYPE cmock_line, int32_t* blockId, size_t cmock_size);
      |                                                                                                     ~~~~~~~~~^~~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/test/unit-test/downloader_utest.c:641:67: warning: passing argument 2 of ‘CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_blockSize’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  641 |     CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_blockSize( &expectedBlockSize );
      |                                                                   ^~~~~~~~~~~~~~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/build/unit-test/mocks/mock_MQTTFileDownloader_cbor.h:55:160: note: in definition of macro ‘CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_blockSize’
   55 | #define CBOR_Decode_GetStreamResponseMessage_ReturnThruPtr_blockSize(blockSize) CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_blockSize(__LINE__, blockSize, sizeof(int32_t))
      |                                                                                                                                                                ^~~~~~~~~
/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/build/unit-test/mocks/mock_MQTTFileDownloader_cbor.h:58:112: note: expected ‘int32_t *’ {aka ‘int *’} but argument is of type ‘const int32_t *’ {aka ‘const int *’}
   58 | void CBOR_Decode_GetStreamResponseMessage_CMockReturnMemThruPtr_blockSize(UNITY_LINE_TYPE cmock_line, int32_t* blockSize, size_t cmock_size);
```

Memory statistics test
```
/home/runner/work/_actions/FreeRTOS/CI-CD-Github-Actions/main/memory_statistics/memory_statistics.py --config ".github/memory_statistics_config.json" --output "size_table.html"
```
Before applying this patch, the issue encountered

```
source/MQTTFileDownloader_cbor.c: In function 'CBOR_Decode_GetStreamResponseMessage':
source/MQTTFileDownloader_cbor.c:117:50: warning: passing argument 2 of 'cbor_value_get_int' from incompatible pointer type [-Wincompatible-pointer-types]
  117 |         cborResult = cbor_value_get_int( &value, ( int32_t * ) fileId );
      |                                                  ^~~~~~~~~~~~~~~~~~~~
      |                                                  |
      |                                                  int32_t * {aka long int *}
```

Applying this patch, solves both these issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
