### PR TITLE
Fix CBMC proofs for mqttDownloader_processReceivedDataBlock

### DIFF
--- a/test/cbmc/proofs.c
+++ b/test/cbmc/proofs.c
@@ -127,6 +127,9 @@ void proof_mqttDownloader_processReceivedDataBlock( void )
     MqttFileDownloaderContext_t context = { 0 };
     uint8_t * message;
     size_t messageLength;
+    int32_t fileId;
+    int32_t blockId;
+    int32_t blockSize;
     uint8_t * data;
     size_t dataLength;
     bool ret;
@@ -143,6 +146,9 @@ void proof_mqttDownloader_processReceivedDataBlock( void )
     ret = mqttDownloader_processReceivedDataBlock( &context,
                                                    message,
                                                    messageLength,
+                                                   &fileId,
+                                                   &blockId,
+                                                   &blockSize,
                                                    data,
                                                    &dataLength );
 }


### PR DESCRIPTION
*Issue #, if available:*
CBMC proofs fail for `mqttDownloader_processReceivedDataBlock` with the following error
```
  {
    "messageText": "wrong number of function arguments: expected 8, but got 5",
    "messageType": "ERROR",
    "sourceLocation": {
      "file": "proofs.c",
      "function": "proof_mqttDownloader_processReceivedDataBlock",
      "line": "143",
      "workingDirectory": "/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/test/cbmc"
    }
  },
  {
    "messageText": "CONVERSION ERROR",
    "messageType": "ERROR"
  }
```
*Description of changes:*
This PR fixes CBMC proofs for the `mqttDownloader_processReceivedDataBlock` API .
