### PR TITLE
Remove asserts from static functions

### DIFF
--- a/source/MQTTFileDownloader_base64.c
+++ b/source/MQTTFileDownloader_base64.c
@@ -191,9 +191,6 @@ static Base64Status_t preprocessBase64Index( uint8_t base64Index,
     int64_t numPaddingVal;
     int64_t numWhitespaceVal;
 
-    assert( numPadding != NULL );
-    assert( numWhitespace != NULL );
-
     numPaddingVal = *numPadding;
     numWhitespaceVal = *numWhitespace;
 
@@ -263,8 +260,6 @@ static void updateBase64DecodingBuffer( const uint8_t base64Index,
     uint32_t base64IndexBuffer;
     uint32_t numDataInBuffer;
 
-    assert( base64IndexBufferPtr != NULL );
-    assert( numDataIndexBuffer != NULL );
     assert( base64Index <= SYMBOL_TO_INDEX_MAP_VALUE_UPPER_BOUND );
 
     base64IndexBuffer = *base64IndexBufferPtr;
@@ -322,12 +317,8 @@ static Base64Status_t decodeBase64IndexBuffer( uint32_t * base64IndexBufferPtr,
     uint32_t numDataInBuffer;
     uint32_t numDataToWrite;
 
-    assert( base64IndexBufferPtr != NULL );
-    assert( numDataIndexBuffer != NULL );
     assert( ( *numDataIndexBuffer == 2U ) || ( *numDataIndexBuffer == 3U ) ||
             ( *numDataIndexBuffer == 4U ) );
-    assert( dest != NULL );
-    assert( outputLength != NULL );
 
     outputLen = *outputLength;
     base64IndexBuffer = *base64IndexBufferPtr;


### PR DESCRIPTION
Description
-----------
This PR removes unnecessary asserts from static functions. The NULL check for the pointer variables are unnecessary , since these are static functions and non-NULL values are always passed from the caller functions. As a result, the code coverage increases.

Test Steps
-----------
```
make -C build/ coverage
declare -a EXCLUDE=("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*" "\*vendor/unity\*" "\*_deps\*")
echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
lcov --rc lcov_branch_coverage=1 --list build/coverage.info
```
Before patch
```
                                   |Lines       |Functions  |Branches    
Filename                           |Rate     Num|Rate    Num|Rate     Num
=========================================================================
[/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/source/]
MQTTFileDownloader.c               |97.3%    146| 100%     9|96.0%    100
MQTTFileDownloader_base64.c        |99.0%    103| 100%     4|85.2%     88
MQTTFileDownloader_cbor.c          | 100%     85| 100%     3| 100%     88
=========================================================================
                             Total:|98.5%    334| 100%    16|93.8%    276

```
After patch

```
                                   |Lines       |Functions  |Branches    
Filename                           |Rate     Num|Rate    Num|Rate     Num
=========================================================================
[/home/ubuntu/Temp/karahulx_coreMQTTFileStreams/aws-iot-core-mqtt-file-streams-embedded-c/source/]
MQTTFileDownloader.c               |97.3%    146| 100%     9|96.0%    100
MQTTFileDownloader_base64.c        |98.9%     95| 100%     4|93.1%     72
MQTTFileDownloader_cbor.c          | 100%     85| 100%     3| 100%     88
=========================================================================
                             Total:|98.5%    326| 100%    16|96.5%    260
```


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.