### PR TITLE
Fix for MISRA compliance

### DIFF
--- a/source/MQTTFileDownloader_cbor.c
+++ b/source/MQTTFileDownloader_cbor.c
@@ -114,7 +114,7 @@ bool CBOR_Decode_GetStreamResponseMessage( const uint8_t * messageBuffer,
 
     if( CborNoError == cborResult )
     {
-        cborResult = cbor_value_get_int( &value, ( int * ) fileId );
+        cborResult = cbor_value_get_int( &value, ( int32_t * ) fileId );
     }
 
     /* Find the block ID. */
@@ -132,7 +132,7 @@ bool CBOR_Decode_GetStreamResponseMessage( const uint8_t * messageBuffer,
 
     if( CborNoError == cborResult )
     {
-        cborResult = cbor_value_get_int( &value, ( int * ) blockId );
+        cborResult = cbor_value_get_int( &value, ( int32_t * ) blockId );
     }
 
     /* Find the block size. */
@@ -150,7 +150,7 @@ bool CBOR_Decode_GetStreamResponseMessage( const uint8_t * messageBuffer,
 
     if( CborNoError == cborResult )
     {
-        cborResult = cbor_value_get_int( &value, ( int * ) blockSize );
+        cborResult = cbor_value_get_int( &value, ( int32_t * ) blockSize );
     }
 
     /* Find the payload bytes. */


### PR DESCRIPTION
Description
-----------
This PR reverts the unit-test changes in #25 to fix MISRA C 2012 compliance errors.

The following lines [1](https://github.com/aws/aws-iot-core-mqtt-file-streams-embedded-c/blob/main/source/MQTTFileDownloader_cbor.c#L117) [2](https://github.com/aws/aws-iot-core-mqtt-file-streams-embedded-c/blob/main/source/MQTTFileDownloader_cbor.c#L135) [3](https://github.com/aws/aws-iot-core-mqtt-file-streams-embedded-c/blob/main/source/MQTTFileDownloader_cbor.c#L153) show the following MISRA violation

MISRA_C_2012_directive_4_6_violation:
Using basic numerical type "int" rather than a typedef that includes size and signedness information.

```
cborResult = cbor_value_get_int( &value, ( int * ) blockSize );
```

Reverting the change to 
```
cborResult = cbor_value_get_int( &value, ( int32_t * ) blockSize );
```
addresses the issue.

Test Steps
-----------
```
cov-configure --force --compiler cc --comptype gcc
cmake -B build -S test
cd build/
cov-build --emit-complementary-info --dir cov-out make coverity_analysis
cd cov-out/
cov-analyze --dir . --coding-standard-config ../../tools/coverity/misra.config --tu-pattern "file('.*/source/.*')"
cov-format-errors --dir . --file "source" --exclude-files '(/build/|/test/)' --html-output html-out;
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.