### PR TITLE
Add block size default

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -13,5 +13,8 @@
         "source/include",
         "coreJSON/source/include",
         "tinycbor/src"
+    ],
+    "compiler_flags": [
+        "MQTT_STREAMS_DO_NOT_USE_CUSTOM_CONFIG"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ In AWS IoT, a **stream** is a publicly addressable resource that is an abstracti
 
 More information about streams and MQTT based file delivery can be found [here](https://docs.aws.amazon.com/iot/latest/developerguide/mqtt-based-file-delivery.html)
 
+## MQTT File Streams Config File
+
+The MQTT file streams library exposes build configuration macros that are required for
+building the library. A list of all the configurations and their default values
+are defined in
+[MQTTFileDownloader_defaults.h](source/include/MQTTFileDownloader_defaults.h). To
+provide custom values for the configuration macros, a custom config file named
+`MQTTFileDownloader_config.h` can be provided by the application to the library.
+
+By default, a `MQTTFileDownloader_config.h` custom config is required to build the
+library. To disable this requirement and build the library with default
+configuration values, provide `MQTT_STREAMS_DO_NOT_USE_CUSTOM_CONFIG` as a compile time
+preprocessor macro.
+
+**Thus, the MQTT library can be built by either**:
+
+- Defining a `MQTTFileDownloader_config.h` file in the application, and adding it to the
+  include directories list of the library
+  **OR**
+- Defining the `MQTT_STREAMS_DO_NOT_USE_CUSTOM_CONFIG` preprocessor macro for the
+  library build.
+
 ### MQTT File Streams library workflow
 
 ![alt text](./docs/doxygen/images/MqttStreams_flowChart.jpg)

--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include "MQTTFileDownloader.h"
+#include "MQTTFileDownloader_defaults.h"
 #include "MQTTFileDownloader_base64.h"
 #include "MQTTFileDownloader_cbor.h"
 #include "core_json.h"

--- a/source/include/MQTTFileDownloader.h
+++ b/source/include/MQTTFileDownloader.h
@@ -25,42 +25,36 @@
  * These first few are topic extensions to the dynamic base topic that includes
  * the Thing name.
  */
-#define MQTT_API_THINGS                         "$aws/things/" /*!< Topic prefix for thing APIs. */
-#define MQTT_API_STREAMS                        "/streams/"    /*!< Stream API identifier. */
-#define MQTT_API_DATA_CBOR                      "/data/cbor"   /*!< Stream API suffix. */
-#define MQTT_API_GET_CBOR                       "/get/cbor"    /*!< Stream API suffix. */
-#define MQTT_API_DATA_JSON                      "/data/json"   /*!< JSON DATA Stream API suffix. */
-#define MQTT_API_GET_JSON                       "/get/json"    /*!< JSON GET Stream API suffix. */
+#define MQTT_API_THINGS                   "$aws/things/"       /*!< Topic prefix for thing APIs. */
+#define MQTT_API_STREAMS                  "/streams/"          /*!< Stream API identifier. */
+#define MQTT_API_DATA_CBOR                "/data/cbor"         /*!< Stream API suffix. */
+#define MQTT_API_GET_CBOR                 "/get/cbor"          /*!< Stream API suffix. */
+#define MQTT_API_DATA_JSON                "/data/json"         /*!< JSON DATA Stream API suffix. */
+#define MQTT_API_GET_JSON                 "/get/json"          /*!< JSON GET Stream API suffix. */
 
 /**
  * @ingroup mqtt_file_downloader_const_types
  * Maximum stream name length.
  */
-#define STREAM_NAME_MAX_LEN                     44U
+#define STREAM_NAME_MAX_LEN               44U
 
 /**
  * @ingroup mqtt_file_downloader_const_types
  * Length of NULL character. Used in calculating lengths of MQTT topics.
  */
-#define NULL_CHAR_LEN                           1U
+#define NULL_CHAR_LEN                     1U
 
 /**
  * @ingroup mqtt_file_downloader_const_types
  * Maximum thing name length.
  */
-#define MAX_THINGNAME_LEN                       128U
+#define MAX_THINGNAME_LEN                 128U
 
 /**
  * @ingroup mqtt_file_downloader_const_types
  * Stream Request Buffer Size
  */
-#define GET_STREAM_REQUEST_BUFFER_SIZE          256U
-
-/**
- * @ingroup mqtt_file_downloader_const_types
- * @brief Configure the Maximum size of the data payload.
- */
-#define mqttFileDownloader_CONFIG_BLOCK_SIZE    256U
+#define GET_STREAM_REQUEST_BUFFER_SIZE    256U
 
 /**
  * @brief Macro to calculate string length.

--- a/source/include/MQTTFileDownloader_defaults.h
+++ b/source/include/MQTTFileDownloader_defaults.h
@@ -1,0 +1,40 @@
+/*
+ * AWS IoT Core MQTT File Streams Embedded C v1.1.0
+ * Copyright (C) 2023 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License. See the LICENSE accompanying this file
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * @file MQTTFileDownloader_defaults.h
+ * @brief Default values for various MQTT stream macros.
+ */
+
+#ifndef MQTT_FILE_DOWNLOADER_DEFAULT_H
+#define MQTT_FILE_DOWNLOADER_DEFAULT_H
+
+#include <stdint.h>
+
+/* MQTT_STREAMS_DO_NOT_USE_CUSTOM_CONFIG allows building the MQTT
+ * streams library without a custom config. If a custom config is
+ * provided, the MQTT_STREAMS_DO_NOT_USE_CUSTOM_CONFIG macro should not
+ * be defined. */
+#ifndef MQTT_STREAMS_DO_NOT_USE_CUSTOM_CONFIG
+    /* Include custom config file before other, non-standard headers. */
+    #include "MQTTFileDownloader_config.h"
+#endif
+
+/**
+ * @ingroup mqtt_file_downloader_const_types
+ * @brief Configure the Maximum size of the data payload. The
+ * smallest value is 256 bytes, maximum is 128KB. For more see
+ * https://docs.aws.amazon.com/general/latest/gr/iot-core.html
+ */
+#ifndef mqttFileDownloader_CONFIG_BLOCK_SIZE
+    #define mqttFileDownloader_CONFIG_BLOCK_SIZE    4096U
+#endif
+
+#endif /* #ifndef MQTT_FILE_DOWNLOADER_DEFAULT_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,9 @@ if( COV_ANALYSIS )
   # JOBS public include path.
   target_include_directories( coverity_analysis PUBLIC ${MQTT_FILE_DOWNLOADER_INCLUDES} )
 
+  # Build MQTT streams library target without custom config dependency.
+  target_compile_definitions( coverity_analysis PUBLIC MQTT_STREAMS_DO_NOT_USE_CUSTOM_CONFIG=1 )
+
   # Build HTTP library target without logging
   target_compile_options(coverity_analysis PUBLIC -DNDEBUG )
 
@@ -132,8 +135,7 @@ if( UNITTEST )
   # Include build configuration for unit tests.
   add_subdirectory(unit-test)
 
-  # ==================================== Coverage Analysis configuration
-  # ========================================
+  # ================= Coverage Analysis configuration =================
 
   # Add a target for running coverage on tests.
   add_custom_target(

--- a/test/unit-test/MQTTFileDownloader_config.h
+++ b/test/unit-test/MQTTFileDownloader_config.h
@@ -1,0 +1,23 @@
+/*
+ * AWS IoT Core MQTT File Streams Embedded C v1.1.0
+ * Copyright (C) 2023 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License. See the LICENSE accompanying this file
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * @file MQTTFileDownloader_config.h
+ * @brief Testing values for various MQTT stream macros.
+ */
+
+#ifndef MQTT_FILE_DOWNLOADER_CONFIG_H
+#define MQTT_FILE_DOWNLOADER_CONFIG_H
+
+#include <stdint.h>
+
+#define mqttFileDownloader_CONFIG_BLOCK_SIZE    256U
+
+#endif /* #ifndef MQTT_FILE_DOWNLOADER_CONFIG_H */

--- a/test/unit-test/downloader_base64_utest.c
+++ b/test/unit-test/downloader_base64_utest.c
@@ -14,7 +14,7 @@
 
 #include "unity.h"
 #include "MQTTFileDownloader.h"
-
+#include "MQTTFileDownloader_defaults.h"
 #include "MQTTFileDownloader_base64.h"
 
 #define GET_STREAM_REQUEST_BUFFER_SIZE    256U

--- a/test/unit-test/downloader_utest.c
+++ b/test/unit-test/downloader_utest.c
@@ -17,6 +17,7 @@
 #include "mock_MQTTFileDownloader_cbor.h"
 
 #include "MQTTFileDownloader.h"
+#include "MQTTFileDownloader_defaults.h"
 
 #define GET_STREAM_REQUEST_BUFFER_SIZE    256U
 


### PR DESCRIPTION
Description
-----------
Block size for file transfer
should be configurable from 256 bytes to
128 KB.

Test Steps
-----------
To be completed

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/aws/aws-iot-core-mqtt-file-streams-embedded-c/issues/24

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.