### PR TITLE
[WIP]: Bitmap support for GetStreamRequestMessage

### DIFF
--- a/source/MQTTFileDownloader.c
+++ b/source/MQTTFileDownloader.c
@@ -286,6 +286,8 @@ size_t mqttDownloader_createGetDataBlockRequest( DataType_t dataType,
                                                  uint32_t blockSize,
                                                  uint16_t blockOffset,
                                                  uint32_t numberOfBlocksRequested,
+                                                 const uint8_t * blockBitmap,
+                                                 size_t blockBitmapSize,
                                                  char * getStreamRequest,
                                                  size_t getStreamRequestLength )
 {
@@ -303,40 +305,18 @@ size_t mqttDownloader_createGetDataBlockRequest( DataType_t dataType,
 
         if( dataType == DATA_TYPE_JSON )
         {
-            /* MISRA Ref 21.6.1 [Use of snprintf] */
-            /* More details at: https://github.com/aws/aws-iot-core-mqtt-file-streams-embedded-c//blob/main/MISRA.md#rule-216 */
-            /* coverity[misra_c_2012_rule_21_6_violation] */
-            ( void ) snprintf( getStreamRequest,
-                               GET_STREAM_REQUEST_BUFFER_SIZE,
-                               "{"
-                               "\"s\": 1,"
-                               "\"f\": %u,"
-                               "\"l\": %u,"
-                               "\"o\": %u,"
-                               "\"n\": %u"
-                               "}",
-                               fileId,
-                               blockSize,
-                               blockOffset,
-                               numberOfBlocksRequested );
-
-            requestLength = strnlen( getStreamRequest,
-                                     GET_STREAM_REQUEST_BUFFER_SIZE );
+            JSON_Encode_GetStreamRequestMessage();
         }
         else
         {
-            /* MISRA Ref 7.4.1 [Use of string literal] */
-            /* More details at: https://github.com/aws/aws-iot-core-mqtt-file-streams-embedded-c//blob/main/MISRA.md#rule-74 */
             ( void ) CBOR_Encode_GetStreamRequestMessage( ( uint8_t * ) getStreamRequest,
                                                           GET_STREAM_REQUEST_BUFFER_SIZE,
                                                           &requestLength,
-                                                          "rdy",
                                                           fileId,
                                                           blockSize,
                                                           blockOffset,
-                                                          /* coverity[misra_c_2012_rule_7_4_violation] */
-                                                          ( const uint8_t * ) "MQ==",
-                                                          strlen( "MQ==" ),
+                                                          blockBitmap,
+                                                          blockBitmapSize,
                                                           numberOfBlocksRequested );
         }
     }

--- a/source/MQTTFileDownloader_json.c
+++ b/source/MQTTFileDownloader_json.c
@@ -1,0 +1,75 @@
+/*
+ * AWS IoT Core MQTT File Streams Embedded C v1.1.0
+ * Copyright (C) 2023 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License. See the LICENSE accompanying this file
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * @file MQTTFileDownloader_json.c
+ * @brief JSON encode/decode routines.
+ */
+/* Standard includes. */
+#include <stdbool.h>
+
+#include "MQTTFileDownloader_json.h"
+
+#define OPTIONAL_BITMAP_BUFFER_SIZE 24583
+
+bool JSON_Encode_GetStreamRequestMessage(char * messageBuffer,
+                                    size_t messageBufferSize,
+                                    size_t * encodedMessageSize,
+                                    uint16_t fileId,
+                                    uint32_t blockSize,
+                                    uint16_t blockOffset,
+                                    uint32_t numberOfBlocksRequested,
+                                    const uint8_t * blockBitmap,
+                                    size_t blockBitmapSize)
+{
+    bool jsonResult = true;
+    /* Bitmap must be less than 12,288 bytes. */
+    /* More details: https://docs.aws.amazon.com/iot/latest/developerguide/mqtt-based-file-delivery-in-devices.html#mqtt-based-file-delivery-get-getstream */
+    char optionalKeys[OPTIONAL_BITMAP_BUFFER_SIZE] = {};
+
+    if( ( messageBuffer == NULL ) || ( encodedMessageSize == NULL ) )
+    {
+        jsonResult = false;
+    }
+
+    if ( blockBitmap != NULL && blockBitmapSize != 0 )
+    {
+        snprintf(optionalKeys,
+            OPTIONAL_BITMAP_BUFFER_SIZE,
+            "\"b\": \"%.*s\"",
+            ( int ) blockBitmapSize,
+            blockBitmap );
+    }
+
+    if ( jsonResult == true )
+    {
+    /* MISRA Ref 21.6.1 [Use of snprintf] */
+    /* More details at: https://github.com/aws/aws-iot-core-mqtt-file-streams-embedded-c//blob/main/MISRA.md#rule-216 */
+    /* coverity[misra_c_2012_rule_21_6_violation] */
+    ( void ) snprintf( messageBuffer,
+                        messageBufferSize,
+                        "{"
+                        "\"s\": 1,"
+                        "\"f\": %u,"
+                        "\"l\": %u,"
+                        "\"o\": %u,"
+                        "\"n\": %u",
+                        "%s"
+                        "}",
+                        fileId,
+                        blockSize,
+                        blockOffset,
+                        numberOfBlocksRequested,
+                        optionalKeys);
+
+    *encodedMessageSize = strnlen( messageBuffer,
+                             messageBufferSize );
+    }
+}

--- a/source/include/MQTTFileDownloader_json.h
+++ b/source/include/MQTTFileDownloader_json.h
@@ -1,0 +1,29 @@
+/*
+ * AWS IoT Core MQTT File Streams Embedded C v1.1.0
+ * Copyright (C) 2023 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License. See the LICENSE accompanying this file
+ * for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * @file MQTTFileDownloader_json.h
+ * @brief Function declarations and field declarations for
+ * MQTTFileDownloader_json.c.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+bool JSON_Encode_GetStreamRequestMessage(char * messageBuffer,
+                                    size_t messageBufferSize,
+                                    size_t * encodedMessageSize,
+                                    uint16_t fileId,
+                                    uint32_t blockSize,
+                                    uint16_t blockOffset,
+                                    uint32_t numberOfBlocksRequested,
+                                    const uint8_t * blockBitmap,
+                                    size_t blockBitmapSize);


### PR DESCRIPTION
Description
-----------
Work in progress changes to support the bitmap field when building a get stream request messge.

Refs:
* https://docs.aws.amazon.com/iot/latest/developerguide/mqtt-based-file-delivery-in-devices.html#mqtt-based-file-delivery-get-getstream
* https://docs.aws.amazon.com/iot/latest/developerguide/mqtt-based-file-delivery-in-devices.html#mqtt-based-file-delivery-build-a-bitmap

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.